### PR TITLE
feat: Add dual package support (CommonJS + ESM)

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,32 @@
   "version": "0.0.0-development",
   "description": "Library for API access to ZITADEL. Provides compiled gRPC service clients and helpers for applications and service accounts.",
   "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts"
+    },
+    "./dist/api/*": {
+      "import": "./dist/esm/api/*.js",
+      "require": "./dist/cjs/api/*.js",
+      "types": "./dist/types/api/*.d.ts"
+    }
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
     "dev": "tsc -w",
-    "build": "npm run build:grpc && npm run build:tsc",
-    "prebuild:tsc": "rimraf dist",
-    "build:tsc": "tsc",
+    "build": "npm run build:grpc && npm run build:dual",
+    "build:dual": "npm run build:types && npm run build:esm && npm run build:cjs",
+    "prebuild:dual": "rimraf dist",
+    "build:types": "tsc",
+    "build:esm": "tsc -p tsconfig.esm.json",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
     "prebuild:test": "rimraf dist",
     "build:test": "tsc -p tsconfig.test.json",
     "prebuild:grpc": "rimraf src/api/generated && make-dir src/api/generated",
@@ -32,7 +50,9 @@
   "author": "Christoph Bühler, smartive AG, <christoph@smartive.ch>",
   "license": "Apache-2.0",
   "files": [
-    "dist"
+    "dist/esm",
+    "dist/cjs", 
+    "dist/types"
   ],
   "devDependencies": {
     "@bufbuild/buf": "^1.18.0-1",

--- a/src/credentials/index.ts
+++ b/src/credentials/index.ts
@@ -1,2 +1,3 @@
+// Export all credential-related functionality
 export { Application } from './application.js';
 export { ServiceAccount } from './service-account.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+// Main entry point for @zitadel/node
+export * from './api/index.js';
+export * from './credentials/index.js'; 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -2,11 +2,12 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node-lts/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/types",
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "declarationMap": true
+    "outDir": "dist/cjs",
+    "module": "CommonJS",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "declaration": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
-}
+} 

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,11 +2,12 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node-lts/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist/types",
-    "declaration": true,
-    "emitDeclarationOnly": true,
-    "declarationMap": true
+    "outDir": "dist/esm",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "target": "ES2022",
+    "declaration": false
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
-}
+} 


### PR DESCRIPTION
- Add CommonJS build configuration (tsconfig.cjs.json)
- Add ESM build configuration (tsconfig.esm.json)
- Add TypeScript declarations build (tsconfig.json)
- Update package.json with conditional exports and dual build scripts
- Create main entry point (src/index.ts)
- Enable NestJS and CommonJS compatibility while maintaining ESM support

This enables the package to work with both CommonJS (NestJS) and ESM projects.